### PR TITLE
close tcp listener if accept loop is interrupted

### DIFF
--- a/server.scm
+++ b/server.scm
@@ -85,4 +85,6 @@
     (parameterize ((server-port port)
                    (server-bind-address bind-address)
                    (tcp-buffer-size (snowy-buffer-size)))
-      (accept-loop listener f))))
+      (handle-exceptions _ 
+        (tcp-close listener)
+        (accept-loop listener f)))))


### PR DESCRIPTION
This closes the tcp listener after breaking the loop.

I find this useful when I use the server in REPL, where I may start the server multiple times.